### PR TITLE
Fix path to .xcodeproj in ExaconExample.xcworkspace file

### DIFF
--- a/Example/ExaconExample.xcworkspace/contents.xcworkspacedata
+++ b/Example/ExaconExample.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/gautiergdx/Development/Hexacon/Example/HexaconExample.xcodeproj">
+      location = "group:HexaconExample.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:Pods/Pods.xcodeproj">


### PR DESCRIPTION
This commit changes an absolute path to a realtive one. After this operation it is possible to launch the example by opening `ExaconExample.xcworkspace` file.